### PR TITLE
GetAwaiter().GetResult() possible Deadlock fixing.

### DIFF
--- a/src/Dapper.UnitOfWork/Dapper.UnitOfWork.Example/Program.cs
+++ b/src/Dapper.UnitOfWork/Dapper.UnitOfWork.Example/Program.cs
@@ -33,7 +33,7 @@ namespace Dapper.UnitOfWork.Example
 
 			PrintCustomer(newCustomerId);
 
-            MainAsync(args).GetAwaiter().GetResult();
+            Task.Run(async()=> await MainAsync(args));
 
 			Console.WriteLine("Press any key to exit");
 			Console.ReadKey();

--- a/src/Dapper.UnitOfWork/Dapper.UnitOfWork/Retry.cs
+++ b/src/Dapper.UnitOfWork/Dapper.UnitOfWork/Retry.cs
@@ -31,7 +31,7 @@ namespace Dapper.UnitOfWork
                 }
                 catch (Exception ex)
                 {
-                    HandleExceptionAsync(retryOptions, ex, retryCount).GetAwaiter().GetResult();
+                    Task.Run(async()=> await HandleExceptionAsync(retryOptions, ex, retryCount));
                 }
 
                 retryCount++;


### PR DESCRIPTION
As discussed in [this ](https://github.com/outmatic/Dapper.UnitOfWork/issues/5#issue-471622819) issue, i'm opening this pull request, hope it helps with some of the most common problems that can be generated by the GetAwaiter().GetResult().